### PR TITLE
docker.js now sets variables for Pro licenses as well

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,9 @@ on:
 
 env:
   UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+  UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+  UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+  UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
 
 jobs:
   buildForAllPlatforms:

--- a/src/model/docker.js
+++ b/src/model/docker.js
@@ -25,6 +25,9 @@ export default class Docker {
         --workdir /github/workspace \
         --rm \
         --env UNITY_LICENSE \
+        --env UNITY_EMAIL \
+        --env UNITY_PASSWORD \
+        --env UNITY_SERIAL \
         --env UNITY_VERSION=${version} \
         --env PROJECT_PATH=${projectPath} \
         --env BUILD_TARGET=${platform} \


### PR DESCRIPTION
Not sure if anything else needs to be updated, but this should solve my Issue at webbertakken/unity-actions#26.

I set `UNITY_EMAIL`, `UNITY_PASSWORD`, and `UNITY_SERIAL` in my fork so that the test builds would pass, but my Plus license is limited to only 2 activations at a time, so the remaining builds may still fail...