### PR TITLE
Only return the license in professional mode

### DIFF
--- a/builder/steps/return_license.sh
+++ b/builder/steps/return_license.sh
@@ -1,14 +1,16 @@
 #!/usr/bin/env bash
 
-#
-# PROFESSIONAL (SERIAL) LICENSE MODE
-#
-# This will return the license that is currently in use.
-#
-xvfb-run --auto-servernum --server-args='-screen 0 640x480x24' \
-  /opt/Unity/Editor/Unity \
-    -batchmode \
-    -nographics \
-    -logFile /dev/stdout \
-    -quit \
-    -returnlicense
+if [[ -n "$UNITY_SERIAL" ]]; then
+  #
+  # PROFESSIONAL (SERIAL) LICENSE MODE
+  #
+  # This will return the license that is currently in use.
+  #
+  xvfb-run --auto-servernum --server-args='-screen 0 640x480x24' \
+    /opt/Unity/Editor/Unity \
+      -batchmode \
+      -nographics \
+      -logFile /dev/stdout \
+      -quit \
+      -returnlicense
+fi


### PR DESCRIPTION
If $UNITY_SERIAL isn't defined then the license return step gets skipped to help save some time in personal builds.