### PR TITLE
feat(activate): add more checks for licenses

### DIFF
--- a/builder/steps/activate.sh
+++ b/builder/steps/activate.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 
-# Try personal activation
 if [[ -n "$UNITY_LICENSE" ]]; then
-  LICENSE_MODE="personal"
   #
   # PERSONAL LICENSE MODE
   #
@@ -12,6 +10,7 @@ if [[ -n "$UNITY_LICENSE" ]]; then
   #   * See for more details: https://gitlab.com/gableroux/unity3d-gitlab-ci-example/issues/5#note_72815478
   #
   # The license file can be acquired using `webbertakken/request-manual-activation-file` action.
+  LICENSE_MODE="personal"
 
   # Set the license file path
   FILE_PATH=UnityLicenseFile.ulf
@@ -47,9 +46,7 @@ if [[ -n "$UNITY_LICENSE" ]]; then
   # Remove license file
   rm -f $FILE_PATH
 
-# Try professional activation
 elif [[ -n "$UNITY_SERIAL" && -n "$UNITY_EMAIL" && -n "$UNITY_PASSWORD" ]]; then
-  LICENSE_MODE="professional"
   #
   # PROFESSIONAL (SERIAL) LICENSE MODE
   #
@@ -57,6 +54,7 @@ elif [[ -n "$UNITY_SERIAL" && -n "$UNITY_EMAIL" && -n "$UNITY_PASSWORD" ]]; then
   #
   # Note: This is the preferred way for PROFESSIONAL LICENSES.
   #
+  LICENSE_MODE="professional"
 
   xvfb-run --auto-servernum --server-args='-screen 0 640x480x24' \
     /opt/Unity/Editor/Unity \
@@ -71,8 +69,12 @@ elif [[ -n "$UNITY_SERIAL" && -n "$UNITY_EMAIL" && -n "$UNITY_PASSWORD" ]]; then
   # Store the exit code from the verify command
   UNITY_EXIT_CODE=$?
 
-# Exit since personal and professional modes failed
 else
+  #
+  # LICENSE ACTIVATION FAILED
+  #
+  # This will exit since both personal and professional activation modes failed
+  #
   echo "No personal or professional licenses provided!"
   echo "Please ensure you have setup one of these licensing methods:"
   echo "  - Personal: Set the UNITY_LICENSE environment variable."
@@ -81,11 +83,14 @@ else
   exit 1;
 fi
 
+#
 # Display information about the result
+#
 if [ $UNITY_EXIT_CODE -eq 0 ]; then
+  # Activation was a success
   echo "Activation ($LICENSE_MODE) complete."
 else
-  # Exit with the code from the license verification step
+  # Activation failed so exit with the code from the license verification step
   echo "Unclassified error occured while trying to activate ($LICENSE_MODE) license."
   echo "Exit code was: $UNITY_EXIT_CODE"
   exit $UNITY_EXIT_CODE

--- a/builder/steps/activate.sh
+++ b/builder/steps/activate.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
+# Try personal activation
 if [[ -n "$UNITY_LICENSE" ]]; then
+  LICENSE_MODE="personal"
   #
   # PERSONAL LICENSE MODE
   #
@@ -42,23 +44,12 @@ if [[ -n "$UNITY_LICENSE" ]]; then
   # TODO - Derive exit code by grepping success statement
   UNITY_EXIT_CODE=$(echo $ACTIVATION_OUTPUT | grep 'config is NOT valid, switching to default' | wc -l)
 
-  # Display information about the result
-  if [ $UNITY_EXIT_CODE -eq 0 ]; then
-    echo "Activation (personal) complete."
-  else
-    echo "Unclassified error occured while trying to activate (personal) license."
-    echo "Exit code was: $UNITY_EXIT_CODE"
-  fi
-
   # Remove license file
   rm -f $FILE_PATH
 
-  # Exit with the code from the license verification step
-  if [ $UNITY_EXIT_CODE -ne 0 ]; then
-    exit $UNITY_EXIT_CODE
-  fi
-
+# Try professional activation
 elif [[ -n "$UNITY_SERIAL" && -n "$UNITY_EMAIL" && -n "$UNITY_PASSWORD" ]]; then
+  LICENSE_MODE="professional"
   #
   # PROFESSIONAL (SERIAL) LICENSE MODE
   #
@@ -66,6 +57,7 @@ elif [[ -n "$UNITY_SERIAL" && -n "$UNITY_EMAIL" && -n "$UNITY_PASSWORD" ]]; then
   #
   # Note: This is the preferred way for PROFESSIONAL LICENSES.
   #
+
   xvfb-run --auto-servernum --server-args='-screen 0 640x480x24' \
     /opt/Unity/Editor/Unity \
       -batchmode \
@@ -79,22 +71,22 @@ elif [[ -n "$UNITY_SERIAL" && -n "$UNITY_EMAIL" && -n "$UNITY_PASSWORD" ]]; then
   # Store the exit code from the verify command
   UNITY_EXIT_CODE=$?
 
-  # Display information about the result
-  if [ $UNITY_EXIT_CODE -eq 0 ]; then
-    echo "Activation (professional) complete."
-  else
-    echo "Unclassified error occured while trying to activate (professional) license."
-    echo "Exit code was: $UNITY_EXIT_CODE"
-  fi
-
-  # Exit with the code from the license verification step
-  exit $UNITY_EXIT_CODE
+# Exit since personal and professional modes failed
 else
-  # Exit since no license and no serial number provided!
   echo "No personal or professional licenses provided!"
   echo "Please ensure you have setup one of these licensing methods:"
   echo "  - Personal: Set the UNITY_LICENSE environment variable."
   echo "  - Professional: Set the UNITY_EMAIL, UNITY_PASSWORD and UNITY_SERIAL environment variables."
   echo "See https://github.com/webbertakken/unity-builder#usage for details."
   exit 1;
+fi
+
+# Display information about the result
+if [ $UNITY_EXIT_CODE -eq 0 ]; then
+  echo "Activation ($LICENSE_MODE) complete."
+else
+  # Exit with the code from the license verification step
+  echo "Unclassified error occured while trying to activate ($LICENSE_MODE) license."
+  echo "Exit code was: $UNITY_EXIT_CODE"
+  exit $UNITY_EXIT_CODE
 fi

--- a/builder/steps/activate.sh
+++ b/builder/steps/activate.sh
@@ -58,7 +58,7 @@ if [[ -n "$UNITY_LICENSE" ]]; then
     exit $UNITY_EXIT_CODE
   fi
 
-else
+elif [[ -n "$UNITY_SERIAL" && -n "$UNITY_EMAIL" && -n "$UNITY_PASSWORD" ]]; then
   #
   # PROFESSIONAL (SERIAL) LICENSE MODE
   #
@@ -89,5 +89,12 @@ else
 
   # Exit with the code from the license verification step
   exit $UNITY_EXIT_CODE
-
+else
+  # Exit since no license and no serial number provided!
+  echo "No personal or professional licenses provided!"
+  echo "Please ensure you have setup one of these licensing methods:"
+  echo "  - Personal: Set the UNITY_LICENSE environment variable."
+  echo "  - Professional: Set the UNITY_EMAIL, UNITY_PASSWORD and UNITY_SERIAL environment variables."
+  echo "See https://github.com/webbertakken/unity-builder#usage for details."
+  exit 1;
 fi


### PR DESCRIPTION
Adds more checks for professional license details before running a build.
This should stop builds running without a licenses setup and will exit with a more explicit error

Edit: also removed the exit from the professional activation since that was being called even when activation was successful 