### PR TITLE
make StandaloneOSX app runnable

### DIFF
--- a/action/steps/build.sh
+++ b/action/steps/build.sh
@@ -123,6 +123,11 @@ else
   echo "Build failed, with exit code $BUILD_EXIT_CODE";
 fi
 
+# Add permissions to make app runnable
+if [[ "$BUILD_TARGET" == "StandaloneOSX" ]]; then
+  chmod +x $BUILD_PATH_FULL/StandaloneOSX.app/Contents/MacOS/*
+fi
+
 #
 # Results
 #

--- a/action/steps/build.sh
+++ b/action/steps/build.sh
@@ -125,7 +125,9 @@ fi
 
 # Add permissions to make app runnable
 if [[ "$BUILD_TARGET" == "StandaloneOSX" ]]; then
-  chmod +x $BUILD_PATH_FULL/StandaloneOSX.app/Contents/MacOS/*
+  ADD_PERMISSIONS_PATH=$BUILD_PATH_FULL/StandaloneOSX.app/Contents/MacOS/*
+  echo "Making the following path executable: $ADD_PERMISSIONS_PATH"
+  chmod +x $ADD_PERMISSIONS_PATH
 fi
 
 #


### PR DESCRIPTION
Potential fix for: https://github.com/webbertakken/unity-builder/issues/77

Questions:
- The contributor guidelines request adding tests, but given that this happens in the shell script I wasn't certain if/how to do that best. Any suggestions, or is a manual verification good enough?
- In the issue it discusses fixing Linux builds as well, but I haven't yet tested if they're broken or determined the path where the executable would need to be updated. Do we want to include that here as well or just Mac?