### PR TITLE
Document additional action inputs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -30,10 +30,22 @@ inputs:
     required: false
     default: 'Semantic'
     description: 'The versioning scheme to use when building the project'
+  version:
+    required: false
+    default: ''
+    description: 'The version, when used with the "Custom" versioning scheme'
   androidVersionCode:
     required: false
     default: ''
     description: 'The android versionCode'
+  customParameters:
+    required: false
+    default: ''
+    description: >
+      Custom parameters to configure the build.
+
+      Parameters must start with a hyphen (-) and may be followed by a value (without hyphen).
+      Parameters without a value will be considered booleans (with a value of true).
 outputs: {}
 branding:
   icon: 'box'


### PR DESCRIPTION
This helps avoid warnings when using previously undocumented inputs