### PR TITLE
Remove androidVersionCode from workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,7 +74,6 @@ jobs:
           projectPath: ${{ matrix.projectPath }}
           unityVersion: ${{ matrix.unityVersion }}
           targetPlatform: ${{ matrix.targetPlatform }}
-          androidVersionCode: ${{ github.run_number }}
           customParameters: -profile SomeProfile -someBoolean -someValue exampleValue
       - uses: actions/upload-artifact@v1
         with:


### PR DESCRIPTION
Removing androidVersionCode from the workflow of this repo to make sure the automatic versioning stays in tact