### PR TITLE
Rename custom -version flag to -buildVersion

### DIFF
--- a/action/default-build-script/Assets/Editor/Builder.cs
+++ b/action/default-build-script/Assets/Editor/Builder.cs
@@ -27,7 +27,7 @@ namespace UnityBuilderAction
       };
 
       // Set version for this build
-      VersionApplicator.SetVersion(options["customProjectVersion"]);
+      VersionApplicator.SetVersion(options["buildVersion"]);
       VersionApplicator.SetAndroidVersionCode(options["androidVersionCode"]);
       
       // Apply Android settings

--- a/action/default-build-script/Assets/Editor/Builder.cs
+++ b/action/default-build-script/Assets/Editor/Builder.cs
@@ -27,7 +27,7 @@ namespace UnityBuilderAction
       };
 
       // Set version for this build
-      VersionApplicator.SetVersion(options["version"]);
+      VersionApplicator.SetVersion(options["customProjectVersion"]);
       VersionApplicator.SetAndroidVersionCode(options["androidVersionCode"]);
       
       // Apply Android settings

--- a/action/steps/build.sh
+++ b/action/steps/build.sh
@@ -119,7 +119,7 @@ xvfb-run --auto-servernum --server-args='-screen 0 640x480x24' \
     -customBuildTarget "$BUILD_TARGET" \
     -customBuildPath "$CUSTOM_BUILD_PATH" \
     -executeMethod "$BUILD_METHOD" \
-    -version "$VERSION" \
+    -customProjectVersion "$VERSION" \
     -androidVersionCode "$ANDROID_VERSION_CODE" \
     -androidKeystoreName "$ANDROID_KEYSTORE_NAME" \
     -androidKeystorePass "$ANDROID_KEYSTORE_PASS" \

--- a/action/steps/build.sh
+++ b/action/steps/build.sh
@@ -119,7 +119,7 @@ xvfb-run --auto-servernum --server-args='-screen 0 640x480x24' \
     -customBuildTarget "$BUILD_TARGET" \
     -customBuildPath "$CUSTOM_BUILD_PATH" \
     -executeMethod "$BUILD_METHOD" \
-    -customProjectVersion "$VERSION" \
+    -buildVersion "$VERSION" \
     -androidVersionCode "$ANDROID_VERSION_CODE" \
     -androidKeystoreName "$ANDROID_KEYSTORE_NAME" \
     -androidKeystorePass "$ANDROID_KEYSTORE_PASS" \


### PR DESCRIPTION
`-version` is now used (as of 2019.4.8f1 or earlier) by the Unity CLI to print its own version, then exit with code 0. This interferes with `unity-builder`'s version passing, so I propose renaming the argument to something less likely to collide.

I was unable to run Yarn as requested in the contributing guidelines, as I'm missing tons of prerequisites. Besides whatever CI checks this repo can provide, I can confirm that this fixed #136 in my game's workflow.